### PR TITLE
feat: add user notification system for manifest version mismatch

### DIFF
--- a/align_browser/build.py
+++ b/align_browser/build.py
@@ -72,11 +72,8 @@ def build_frontend(
     print(f"Processing experiments directory: {experiments_root}")
 
     # Determine output directory based on mode
-    if dev_mode:
-        print("Development mode: using provided directory")
-    else:
-        # Production mode: copy static assets
-        print(f"Production mode: creating site in {output_dir}")
+    if not dev_mode:
+        print(f"creating site in {output_dir}")
         output_dir.mkdir(parents=True, exist_ok=True)
         copy_static_assets(output_dir)
 
@@ -98,8 +95,6 @@ def build_frontend(
     # Save manifest in data subdirectory
     with open(data_output_dir / "manifest.json", "w") as f:
         json.dump(manifest.model_dump(), f, indent=2)
-
-    print(f"Data generated in {data_output_dir}")
 
     return output_dir
 
@@ -205,6 +200,9 @@ def serve_directory(directory, host="localhost", port=8000):
         with open(file_path, 'rb') as f:
             return [f.read()]
 
+    if actual_port != port:
+        print(f"Port {port} was busy, using port {actual_port} instead")
+    
     # Display appropriate URL based on host
     if host == "0.0.0.0":
         url = f"http://localhost:{actual_port}"
@@ -214,9 +212,6 @@ def serve_directory(directory, host="localhost", port=8000):
     else:
         url = f"http://{host}:{actual_port}"
         print(f"Serving {directory} at {url}")
-
-    if actual_port != port:
-        print(f"Port {port} was busy, using port {actual_port} instead")
 
     print("Press Ctrl+C to stop the server")
     try:

--- a/align_browser/build.py
+++ b/align_browser/build.py
@@ -182,27 +182,27 @@ def serve_directory(directory, host="localhost", port=8000):
 
     def static_app(environ, start_response):
         """Simple WSGI app for serving static files."""
-        path_info = environ['PATH_INFO']
-        if path_info == '/':
-            path_info = '/index.html'
-        
-        file_path = Path(directory) / path_info.lstrip('/')
-        
+        path_info = environ["PATH_INFO"]
+        if path_info == "/":
+            path_info = "/index.html"
+
+        file_path = Path(directory) / path_info.lstrip("/")
+
         if not file_path.exists() or not file_path.is_file():
-            start_response('404 Not Found', [('Content-Type', 'text/plain')])
-            return [b'404 Not Found']
-        
+            start_response("404 Not Found", [("Content-Type", "text/plain")])
+            return [b"404 Not Found"]
+
         content_type, _ = mimetypes.guess_type(str(file_path))
         if content_type is None:
-            content_type = 'application/octet-stream'
-        
-        start_response('200 OK', [('Content-Type', content_type)])
-        with open(file_path, 'rb') as f:
+            content_type = "application/octet-stream"
+
+        start_response("200 OK", [("Content-Type", content_type)])
+        with open(file_path, "rb") as f:
             return [f.read()]
 
     if actual_port != port:
         print(f"Port {port} was busy, using port {actual_port} instead")
-    
+
     # Display appropriate URL based on host
     if host == "0.0.0.0":
         url = f"http://localhost:{actual_port}"

--- a/align_browser/experiment_parser.py
+++ b/align_browser/experiment_parser.py
@@ -236,7 +236,6 @@ def build_manifest_from_experiments(
         input_output_files.add(experiment.experiment_path / "input_output.json")
 
     # Calculate checksums for all files
-    print(f"Calculating checksums for {len(input_output_files)} files...")
     source_file_checksums = calculate_file_checksums(list(input_output_files))
 
     # Process experiments with conflict detection similar to original

--- a/align_browser/static/notifications.js
+++ b/align_browser/static/notifications.js
@@ -1,0 +1,97 @@
+// Notification system for temporary user messages
+// Provides toast-style notifications that auto-dismiss
+
+let notificationContainer = null;
+let notificationQueue = [];
+let isProcessingQueue = false;
+
+// Initialize notification container
+function initNotificationContainer() {
+  if (!notificationContainer) {
+    notificationContainer = document.createElement('div');
+    notificationContainer.id = 'notification-container';
+    notificationContainer.className = 'notification-container';
+    document.body.appendChild(notificationContainer);
+  }
+}
+
+// Create notification element
+function createNotificationElement(message, type = 'warning') {
+  const notification = document.createElement('div');
+  notification.className = `notification notification-${type}`;
+  notification.textContent = message;
+  return notification;
+}
+
+// Show notification with animation
+function displayNotification(notification, duration = 4000) {
+  initNotificationContainer();
+  
+  // Add to container
+  notificationContainer.appendChild(notification);
+  
+  // Trigger slide-in animation
+  requestAnimationFrame(() => {
+    notification.classList.add('notification-show');
+  });
+  
+  // Auto-dismiss after duration
+  setTimeout(() => {
+    dismissNotification(notification);
+  }, duration);
+}
+
+// Dismiss notification with animation
+function dismissNotification(notification) {
+  if (notification && notification.parentNode) {
+    notification.classList.remove('notification-show');
+    notification.classList.add('notification-hide');
+    
+    // Remove from DOM after animation
+    setTimeout(() => {
+      if (notification.parentNode) {
+        notification.parentNode.removeChild(notification);
+      }
+      processNotificationQueue();
+    }, 300);
+  }
+}
+
+// Process queued notifications
+function processNotificationQueue() {
+  if (notificationQueue.length > 0 && !isProcessingQueue) {
+    isProcessingQueue = true;
+    const { message, type, duration } = notificationQueue.shift();
+    const notification = createNotificationElement(message, type);
+    displayNotification(notification, duration);
+    
+    // Reset processing flag after notification is shown
+    setTimeout(() => {
+      isProcessingQueue = false;
+    }, 500);
+  }
+}
+
+// Main function to show notifications
+export function showNotification(message, type = 'warning', duration = 4000) {
+  // Add to queue to prevent overlapping
+  notificationQueue.push({ message, type, duration });
+  
+  // Process immediately if not already processing
+  if (!isProcessingQueue) {
+    processNotificationQueue();
+  }
+}
+
+// Convenience functions for different notification types
+export function showWarning(message, duration = 4000) {
+  showNotification(message, 'warning', duration);
+}
+
+export function showInfo(message, duration = 3000) {
+  showNotification(message, 'info', duration);
+}
+
+export function showError(message, duration = 5000) {
+  showNotification(message, 'error', duration);
+}

--- a/align_browser/static/state.js
+++ b/align_browser/static/state.js
@@ -1,6 +1,8 @@
 // Functional State Management Module
 // Pure functions for managing application state without mutations
 
+import { showWarning } from './notifications.js';
+
 // Constants for KDMA processing
 const KDMA_CONSTANTS = {
   DECIMAL_PRECISION: 10, // For 1 decimal place normalization
@@ -200,7 +202,7 @@ export function decodeStateFromURL() {
       const currentManifest = GlobalState.getManifest();
       if (currentManifest && decodedState.manifestCreatedAt && 
           decodedState.manifestCreatedAt !== currentManifest.generated_at) {
-        console.warn('URL parameters are from a different manifest version, ignoring URL state');
+        showWarning('URL parameters are from an older version and have been reset');
         return null;
       }
       

--- a/align_browser/static/style.css
+++ b/align_browser/static/style.css
@@ -3,6 +3,15 @@
 :root {
   --run-column-min-width: 350px;
   --accent-color: #007bff;
+  --notification-warning: #856404;
+  --notification-warning-bg: #fff3cd;
+  --notification-warning-border: #ffeaa7;
+  --notification-info: #0c5460;
+  --notification-info-bg: #d1ecf1;
+  --notification-info-border: #bee5eb;
+  --notification-error: #721c24;
+  --notification-error-bg: #f8d7da;
+  --notification-error-border: #f5c6cb;
 }
 
 body {
@@ -596,4 +605,61 @@ footer {
   font-weight: 600;
   font-size: 11px;
   flex-shrink: 0;
+}
+
+/* Notification system styles */
+.notification-container {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.notification {
+  padding: 12px 16px;
+  border-radius: 6px;
+  border: 1px solid;
+  font-size: 14px;
+  font-weight: 500;
+  max-width: 400px;
+  min-width: 300px;
+  text-align: center;
+  transform: translateY(-100px);
+  opacity: 0;
+  transition: all 0.3s ease-out;
+  pointer-events: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.notification-show {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.notification-hide {
+  transform: translateY(-100px);
+  opacity: 0;
+}
+
+.notification-warning {
+  background-color: var(--notification-warning-bg);
+  color: var(--notification-warning);
+  border-color: var(--notification-warning-border);
+}
+
+.notification-info {
+  background-color: var(--notification-info-bg);
+  color: var(--notification-info);
+  border-color: var(--notification-info-border);
+}
+
+.notification-error {
+  background-color: var(--notification-error-bg);
+  color: var(--notification-error);
+  border-color: var(--notification-error-border);
 }

--- a/align_browser/test_kdma_parsing.py
+++ b/align_browser/test_kdma_parsing.py
@@ -1,0 +1,119 @@
+"""Tests specifically for KDMA parsing functionality."""
+
+import pytest
+from align_browser.experiment_models import parse_alignment_target_id
+
+
+def test_parse_alignment_target_id_single_kdma():
+    """Test parsing single KDMA alignment targets."""
+
+    # Standard format
+    result = parse_alignment_target_id("ADEPT-June2025-merit-0.0")
+    assert len(result) == 1
+    assert result[0].kdma == "merit"
+    assert result[0].value == 0.0
+
+    # KDMA with underscore
+    result = parse_alignment_target_id("ADEPT-June2025-personal_safety-0.5")
+    assert len(result) == 1
+    assert result[0].kdma == "personal_safety"
+    assert result[0].value == 0.5
+
+    # Short format (directory name style)
+    result = parse_alignment_target_id("personal_safety-0.0")
+    assert len(result) == 1
+    assert result[0].kdma == "personal_safety"
+    assert result[0].value == 0.0
+
+    # Another standard case
+    result = parse_alignment_target_id("ADEPT-June2025-affiliation-1.0")
+    assert len(result) == 1
+    assert result[0].kdma == "affiliation"
+    assert result[0].value == 1.0
+
+
+def test_parse_alignment_target_id_multi_kdma():
+    """Test parsing multi-KDMA alignment targets."""
+
+    # Two KDMAs without underscores in names
+    result = parse_alignment_target_id("ADEPT-June2025-affiliation_merit-0.0_0.5")
+    assert len(result) == 2
+
+    # Sort by KDMA name for consistent comparison
+    result = sorted(result, key=lambda x: x.kdma)
+    assert result[0].kdma == "affiliation"
+    assert result[0].value == 0.0
+    assert result[1].kdma == "merit"
+    assert result[1].value == 0.5
+
+    # Three values
+    result = parse_alignment_target_id("ADEPT-June2025-a_b_c-0.1_0.2_0.3")
+    assert len(result) == 3
+    result = sorted(result, key=lambda x: x.kdma)
+    assert result[0].kdma == "a"
+    assert result[0].value == 0.1
+    assert result[1].kdma == "b"
+    assert result[1].value == 0.2
+    assert result[2].kdma == "c"
+    assert result[2].value == 0.3
+
+
+def test_parse_alignment_target_id_edge_cases():
+    """Test edge cases and invalid inputs."""
+
+    # Unaligned
+    result = parse_alignment_target_id("unaligned")
+    assert result == []
+
+    # Empty string
+    result = parse_alignment_target_id("")
+    assert result == []
+
+    # None
+    result = parse_alignment_target_id(None)
+    assert result == []
+
+    # Invalid format - no hyphens
+    result = parse_alignment_target_id("merit0.0")
+    assert result == []
+
+    # Invalid format - not enough parts
+    result = parse_alignment_target_id("merit")
+    assert result == []
+
+    # Invalid format - missing value
+    result = parse_alignment_target_id("ADEPT-June2025-merit")
+    assert result == []
+
+    # Invalid format - bad float value
+    result = parse_alignment_target_id("ADEPT-June2025-merit-invalid")
+    assert result == []
+
+    # Mismatched KDMA names and values count (should not happen with new logic for single values)
+    # This case would be handled properly now since single values treat the whole kdma_part as one name
+
+
+def test_parse_alignment_target_id_regression_personal_safety():
+    """Regression test for the specific personal_safety bug."""
+
+    # This was the main failing case
+    result = parse_alignment_target_id("personal_safety-0.0")
+    assert len(result) == 1
+    assert result[0].kdma == "personal_safety"
+    assert result[0].value == 0.0
+
+    # Longer format that was also failing
+    result = parse_alignment_target_id("ADEPT-June2025-personal_safety-0.0")
+    assert len(result) == 1
+    assert result[0].kdma == "personal_safety"
+    assert result[0].value == 0.0
+
+    # Ensure other underscore-containing KDMA names work
+    result = parse_alignment_target_id("some_other_kdma-1.0")
+    assert len(result) == 1
+    assert result[0].kdma == "some_other_kdma"
+    assert result[0].value == 1.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ description = "Static web application for visualizing ADM results"
 requires-python = ">=3.10"
 dependencies = [
     "pyyaml",
-    "pydantic"
+    "pydantic",
+    "waitress"
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "waitress" },
 ]
 
 [package.dev-dependencies]
@@ -26,6 +27,7 @@ dev = [
 requires-dist = [
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "waitress" },
 ]
 
 [package.metadata.requires-dev]
@@ -713,4 +715,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "waitress"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
 ]


### PR DESCRIPTION
## Summary
- Add user-facing notification system to replace console warnings when URL parameters are from different manifest versions
- Implement toast-style notifications that slide down from top of page and auto-dismiss after 4 seconds
- Replace console warning with user-friendly message: "URL parameters are from an older version and have been reset"

## Changes
- **Created `notifications.js`**: Standalone notification system with queue management and animations
- **Updated `state.js`**: Import notification module and replace console.warn with user notification
- **Enhanced `style.css`**: Added notification styling with slide animations and color schemes

## Test plan
- [ ] Load page with URL parameters from different manifest version
- [ ] Verify notification appears at top of page with warning styling
- [ ] Confirm notification auto-dismisses after 4 seconds
- [ ] Test notification queue works with multiple notifications
- [ ] Ensure no console errors in browser

Closes #29